### PR TITLE
API changes for clone-on-boot

### DIFF
--- a/generator/src/control.ml
+++ b/generator/src/control.ml
@@ -60,7 +60,11 @@ let api =
             "protocols, he list should be sorted into descending order of ";
             "desirability. Xapi will open the most desirable URI for which it has ";
             "an available datapath plugin.";
-          ]
+          ];
+          "keys", Dict(String, Basic String), String.concat " " [
+            "A lit of key=value pairs which have been stored in the Volume ";
+            "metadata. These should not be interpreted by the Volume plugin.";
+          ];
         ]
       )) in
   let volume = Type.Name "volume" in
@@ -272,6 +276,27 @@ let api =
                 { Arg.name = "new_description";
                   ty = Basic String;
                   description = "New description"
+                }
+            ];
+              outputs = [
+              ];
+            }; {
+              Method.name = "set";
+              description = String.concat " " [
+                "[set sr volume key value] associates [key] with [value] in the metadata of [volume]";
+                "Note these keys and values are not interpreted by the plugin; they are intended for";
+                "the higher-level software only.";
+              ];
+              inputs = [
+                sr;
+                key;
+                { Arg.name = "k";
+                  ty = Basic String;
+                  description = "Key"
+                }; {
+                  Arg.name = "v";
+                  ty = Basic String;
+                  description = "Value"
                 }
             ];
               outputs = [

--- a/generator/src/control.ml
+++ b/generator/src/control.ml
@@ -214,6 +214,8 @@ let api =
                 "[snapshot sr volume] creates a new volue which is a ";
                 "snapshot of [volume] in [sr]. Snapshots should never be";
                 "written to; they are intended for backup/restore only.";
+                "Note the name and description are copied but any extra";
+                "metadata associated by [set] is not copied.";
               ];
               inputs = [
                 sr;
@@ -229,7 +231,8 @@ let api =
               Method.name = "clone";
               description = String.concat " " [
                 "[clone sr volume] creates a new volume which is a writable";
-                "clone of [volume] in [sr].";
+                "clone of [volume] in [sr]. Note the name and description are";
+                "copied but any extra metadata associated by [set] is not copied.";
               ];
               inputs = [
                 sr;
@@ -297,6 +300,23 @@ let api =
                   Arg.name = "v";
                   ty = Basic String;
                   description = "Value"
+                }
+            ];
+              outputs = [
+              ];
+            }; {
+              Method.name = "remove";
+              description = String.concat " " [
+                "[remove sr volume key] removes [key] and any value associated with it from the metadata of [volume]";
+                "Note these keys and values are not interpreted by the plugin; they are intended for";
+                "the higher-level software only.";
+              ];
+              inputs = [
+                sr;
+                key;
+                { Arg.name = "k";
+                  ty = Basic String;
+                  description = "Key"
                 }
             ];
               outputs = [

--- a/generator/src/control.ml
+++ b/generator/src/control.ml
@@ -305,9 +305,9 @@ let api =
               outputs = [
               ];
             }; {
-              Method.name = "remove";
+              Method.name = "unset";
               description = String.concat " " [
-                "[remove sr volume key] removes [key] and any value associated with it from the metadata of [volume]";
+                "[unset sr volume key] removes [key] and any value associated with it from the metadata of [volume]";
                 "Note these keys and values are not interpreted by the plugin; they are intended for";
                 "the higher-level software only.";
               ];

--- a/generator/src/data.ml
+++ b/generator/src/data.ml
@@ -18,6 +18,16 @@ let backend = {
   description = "The Xen block backend configuration."
 }
 
+let persistent = {
+  Arg.name = "persistent";
+  ty = Type.(Basic Boolean);
+  description = String.concat "" [
+    "True means the disk data is persistent and should be preserved when the datapath ";
+    "is closed i.e. when a VM is shutdown or rebooted. False means the data should be ";
+    "thrown away when the VM is shutdown or rebooted.";
+  ]
+}
+
 let implementation = Type.Variant (
   ("Blkback", Type.(Basic String), "use kernel blkback with the given 'params' key"), [
    "Tapdisk3", Type.(Basic String), "use userspace tapdisk3 with the given 'params' key";
@@ -95,6 +105,20 @@ let api =
          ];
         methods = [
           {
+            Method.name = "open";
+            description = String.concat " "[
+              "[open uri persistent] is called before a disk is attached to a VM. If";
+              "persistent is true then care should be taken to persist all writes to the";
+              "disk. If persistent is false then the implementation should configure";
+              "a temporary location for writes so they can be thrown away on [close]."
+            ];
+            inputs = [
+              uri;
+              persistent;
+            ];
+            outputs = [
+            ];
+          }; {
             Method.name = "attach";
             description = String.concat " "[
               "[attach uri domain] prepares a connection between the storage";
@@ -161,6 +185,17 @@ let api =
             inputs = [
               uri;
               domain;
+            ];
+            outputs = [
+            ];
+          }; {
+            Method.name = "close";
+            description = String.concat " "[
+              "[close uri] is called after a disk is detached and a VM shutdown.";
+              "This is an opportunity to throw away writes if the disk is not persistent.";
+            ];
+            inputs = [
+              uri;
             ];
             outputs = [
             ];

--- a/python/Makefile
+++ b/python/Makefile
@@ -16,3 +16,6 @@ install: build
 .PHONY: uninstall
 uninstall:
 	echo "I don't know how to uninstall python code"
+
+.PHONY: reinstall
+reinstall: install


### PR DESCRIPTION
This can be done in 2 different ways:

If the datapath supports it naturally (e.g. tapdisk + vhd deltas), then the datapath `Plugin.Query` should expose capability `NONPERSISTENT` and implement `Datapath.open` and `Datapath.close`.

When a VM starts we will execute
- `Datapath.open`
- `Datapath.attach`
- `Datapath.activate`

When a VM migrates we will execute
- `Datapath.attach`
- `Datapath.deactivate`
- `Datapath.activate`
- `Datapath.detach`

When a VM shuts down we will execute
- `Datapath.deactivate`
- `Datapath.detach`
- `Datapath.close`

This also adds the ability to store arbitrary key=value pairs with the Volumes. These key = value pairs are intended for the higher-level software only i.e. they are not interpreted by the plugin implementations. These will be used to implement clone-on-boot without datapath support.