### PR TITLE
Add a `required_cluster_stack` list

### DIFF
--- a/generator/src/plugin.ml
+++ b/generator/src/plugin.ml
@@ -28,7 +28,8 @@ let api =
             "version", Basic String, "version";
             "required_api_version", Basic String, "minimum required API version";
             "features", Array (Basic String), "features supported by this plugin";
-            "configuration", Dict(String, Basic String), "key/description pairs describing required device_config parameters"
+            "configuration", Dict(String, Basic String), "key/description pairs describing required device_config parameters";
+            "required_cluster_stack", Array (Basic String), "the plugin requires one of these cluster stacks to be active";
           ]))
       }
     ];


### PR DESCRIPTION
Some storage implementations will require the use of a cluster stack;
for example OCFS2 requires either O2CB or pacemaker/corosync. This
will allow higher-level software to configure the necessary cluster
stack before creating and using any storage.

Signed-off-by: David Scott <dave.scott@citrix.com>